### PR TITLE
Update zookeeper_impl.rb

### DIFF
--- a/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
+++ b/cookbooks/bcpc-hadoop/recipes/zookeeper_impl.rb
@@ -23,8 +23,8 @@ end
 ruby_block "Compare_zookeeper_server_start_shell_script" do
   block do
     require "digest"
-    orig_checksum=Digest::MD5.hexdigest(File.read("/tmp/zkServer.sh"))
-    new_checksum=Digest::MD5.hexdigest(File.read("/usr/hdp/2.2.0.0-2041/zookeeper/bin/zkServer.sh"))
+    orig_checksum = Digest::SHA2.new(512).hexdigest(File.read("/tmp/zkServer.sh"))
+    new_checksum  = Digest::SHA2.new(512).hexdigest(File.read("/usr/hdp/2.2.0.0-2041/zookeeper/bin/zkServer.sh"))
     if orig_checksum != new_checksum
       Chef::Application.fatal!("zookeeper-server:New version of zkServer.sh need to be created and used")
     end


### PR DESCRIPTION
I am a security researcher, who is looking for coding patterns that are indicative of security weaknesses in Chef scripts. In your repo I found instances of MD5 usage within Chef scripts. MD5 is breakable (http://merlot.usc.edu/csac-f06/papers/Wang05a.pdf). According to the Common Weakness Enumeration organization this is a security weakness
(CWE-327: Use of a Broken or Risky Cryptographic Algorithm https://cwe.mitre.org/data/definitions/327.html).

MD5 has security weaknesses, better to use SHA 512. Any feedback is appreciated.